### PR TITLE
WIP: Build args

### DIFF
--- a/.github/workflows/dockerimage-selfhosted.yml
+++ b/.github/workflows/dockerimage-selfhosted.yml
@@ -1,0 +1,125 @@
+name: docker image
+
+on:
+  workflow_call:
+    inputs:
+      build_args:
+        default: ''
+        description: Additional build arguments in `KEY=VALUE` format, preferrably one per line
+        required: false
+        type: string
+      container_name:
+        description: The base name of the docker container; e.g. just the "xyz" part of "edence/xyz:latest"
+        required: true
+        type: string
+      context_path:
+        default: .
+        description: The path (relative within the repo) of the directory that contains the Dockerfile
+        required: false
+        type: string
+      dockerhub_org:
+        default: edence
+        description: The Docker Hub organization name or username where the image should be uploaded; e.g. just the "edence" part of "edence/xyz:latest"; leave blank to skip the normal Docker Hub tag
+        required: false
+        type: string
+      github_org:
+        default: edencehealth
+        description: The GitHub organization name or username where the image should be uploaded; e.g. just the "edencehealth" part of "edencehealth/xyz:latest"; leave blank to skip the normal GitHub tag
+        required: false
+        type: string
+      platforms:
+        default: linux/amd64,linux/arm64
+        description: The comma-separated target platform(s) to use when building the image
+        required: false
+        type: string
+      push:
+        default: ${{ github.event_name != 'pull_request' }}
+        description: Whether to push the image to the container registries (building without pushing may be useful as a PR check)
+        required: false
+        type: boolean
+      registry_paths:
+        default: ''
+        description: Additional registry paths in `KEY=VALUE` format, preferrably one per line
+        required: false
+        type: string
+    secrets:
+      dockerhub_username:
+        description: The Docker Hub username to use when uploading the image
+        required: true
+      dockerhub_token:
+        description: The Docker Hub personal access token to use when uploading the image
+        required: true
+    outputs:
+      tags:
+        description: The docker tags that were ultimately generated
+        value: ${{ jobs.image.outputs.tags }}
+
+jobs:
+  image:
+    runs-on: [self-hosted, linux]
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # https://github.com/docker/login-action
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.dockerhub_username }}
+          password: ${{ secrets.dockerhub_token }}
+
+      # https://github.com/docker/login-action
+      - name: Login to github container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ inputs.github_org != '' && format('ghcr.io/{0}/{1}', inputs.github_org, inputs.container_name) || '' }}
+            ${{ inputs.dockerhub_org != '' && format('{0}/{1}', inputs.dockerhub_org, inputs.container_name) || '' }}
+            ${{ inputs.registry_paths != '' && inputs.registry_paths || '' }}
+          tags: |
+            type=schedule
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=ref,event=pr
+            type=sha
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ inputs.context_path }}
+          push: ${{ inputs.push }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+          platforms: ${{ inputs.platforms }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            ${{ inputs.build_args != '' && inputs.build_args || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -44,10 +44,16 @@ on:
       dockerhub_token:
         description: The Docker Hub personal access token to use when uploading the image
         required: true
+    outputs:
+      tags:
+        description: The docker tags that were ultimately generated
+        value: ${{ jobs.image.outputs.tags }}
 
 jobs:
   image:
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout the code

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_args:
-        default: ""
+        default: ''
         description: Additional build arguments in `KEY=VALUE` format, preferrably one per line
         required: false
         type: string
@@ -19,12 +19,12 @@ on:
         type: string
       dockerhub_org:
         default: edence
-        description: The Docker Hub organization name or username where the image should be uploaded; e.g. just the "edence" part of "edence/xyz:latest"
+        description: The Docker Hub organization name or username where the image should be uploaded; e.g. just the "edence" part of "edence/xyz:latest"; leave blank to skip the normal Docker Hub tag
         required: false
         type: string
       github_org:
         default: edencehealth
-        description: The GitHub organization name or username where the image should be uploaded; e.g. just the "edencehealth" part of "edencehealth/xyz:latest"
+        description: The GitHub organization name or username where the image should be uploaded; e.g. just the "edencehealth" part of "edencehealth/xyz:latest"; leave blank to skip the normal GitHub tag
         required: false
         type: string
       platforms:
@@ -37,6 +37,11 @@ on:
         description: Whether to push the image to the container registries (building without pushing may be useful as a PR check)
         required: false
         type: boolean
+      registry_paths:
+        default: ''
+        description: Additional registry paths in `KEY=VALUE` format, preferrably one per line
+        required: false
+        type: string
     secrets:
       dockerhub_username:
         description: The Docker Hub username to use when uploading the image
@@ -88,8 +93,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/${{ inputs.github_org }}/${{ inputs.container_name }}
-            ${{ inputs.dockerhub_org }}/${{ inputs.container_name }}
+            ${{ inputs.github_org != '' && format('ghcr.io/{0}/{1}', inputs.github_org, inputs.container_name) }}
+            ${{ inputs.dockerhub_org != '' && format('{0}/{1}', inputs.dockerhub_org, inputs.container_name) }}
+            ${{ inputs.registry_paths != '' && inputs.registry_paths }}
           tags: |
             type=schedule
             type=semver,pattern={{version}}
@@ -114,6 +120,6 @@ jobs:
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
-            ${{ inputs.build_args }}
+            ${{ inputs.build_args != '' && inputs.build_args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,9 +3,19 @@ name: docker image
 on:
   workflow_call:
     inputs:
+      build_args:
+        default: ""
+        description: Additional build arguments in `KEY=VALUE` format, preferrably one per line
+        required: false
+        type: string
       container_name:
         description: The base name of the docker container; e.g. just the "xyz" part of "edence/xyz:latest"
         required: true
+        type: string
+      context_path:
+        default: .
+        description: The path (relative within the repo) of the directory that contains the Dockerfile
+        required: false
         type: string
       dockerhub_org:
         default: edence
@@ -15,11 +25,6 @@ on:
       github_org:
         default: edencehealth
         description: The GitHub organization name or username where the image should be uploaded; e.g. just the "edencehealth" part of "edencehealth/xyz:latest"
-        required: false
-        type: string
-      context_path:
-        default: .
-        description: The path (relative within the repo) of the directory that contains the Dockerfile
         required: false
         type: string
       platforms:
@@ -103,5 +108,6 @@ jobs:
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
+            ${{ inputs.build_args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -93,9 +93,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ inputs.github_org != '' && format('ghcr.io/{0}/{1}', inputs.github_org, inputs.container_name) }}
-            ${{ inputs.dockerhub_org != '' && format('{0}/{1}', inputs.dockerhub_org, inputs.container_name) }}
-            ${{ inputs.registry_paths != '' && inputs.registry_paths }}
+            ${{ inputs.github_org != '' && format('ghcr.io/{0}/{1}', inputs.github_org, inputs.container_name) || '' }}
+            ${{ inputs.dockerhub_org != '' && format('{0}/{1}', inputs.dockerhub_org, inputs.container_name) || '' }}
+            ${{ inputs.registry_paths != '' && inputs.registry_paths || '' }}
           tags: |
             type=schedule
             type=semver,pattern={{version}}
@@ -120,6 +120,6 @@ jobs:
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
-            ${{ inputs.build_args != '' && inputs.build_args }}
+            ${{ inputs.build_args != '' && inputs.build_args || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/venv
 **/.venv
 **/.mypy_cache
-
+**/.vscode

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ edencehealth/workflows/.github/workflows/dockerimage.yml@main
 
 ### Inputs
 
-input name       | required | type    | default                    | description
----------------- | -------- | ------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------
-`build_args`     | False    | string  | ``                         | Additional build arguments in `KEY=VALUE` format, preferrably one per line
-`container_name` | True     | string  | &nbsp;                     | The base name of the docker container; e.g. just the `xyz` part of `edence/xyz:latest`
-`context_path`   | False    | string  | `.`                        | The path (relative within the repo) of the directory that contains the Dockerfile
-`dockerhub_org`  | False    | string  | `edence`                   | The Docker Hub organization name or username where the image should be uploaded; e.g. just the `edence` part of `edence/xyz:latest`
-`github_org`     | False    | string  | `edencehealth`             | The GitHub organization name or username where the image should be uploaded; e.g. just the `edencehealth` part of `edencehealth/xyz:latest`
-`platforms`      | False    | string  | `linux/amd64,linux/arm64`  | The comma-separated target platform(s) to use when building the image
-`push`           | False    | boolean | True if not a pull request | Whether to push the image to the container registries (building without pushing may be useful as a PR check)
+input name       | required | type    | default                                      | description
+---------------- | -------- | ------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+`build_args`     | False    | string  | ""                                           | Additional build arguments in `KEY=VALUE` format, preferrably one per line
+`container_name` | True     | string  | `-`                                          | The base name of the docker container; e.g. just the "xyz" part of "edence/xyz:latest"
+`context_path`   | False    | string  | `.`                                          | The path (relative within the repo) of the directory that contains the Dockerfile
+`dockerhub_org`  | False    | string  | `edence`                                     | The Docker Hub organization name or username where the image should be uploaded; e.g. just the "edence" part of "edence/xyz:latest"; leave blank to skip the normal Docker Hub tag
+`github_org`     | False    | string  | `edencehealth`                               | The GitHub organization name or username where the image should be uploaded; e.g. just the "edencehealth" part of "edencehealth/xyz:latest"; leave blank to skip the normal GitHub tag
+`platforms`      | False    | string  | `linux/amd64,linux/arm64`                    | The comma-separated target platform(s) to use when building the image
+`push`           | False    | boolean | `${{ github.event_name != 'pull_request' }}` | Whether to push the image to the container registries (building without pushing may be useful as a PR check)
+`registry_paths` | False    | string  | ``                                           | Additional registry paths in `KEY=VALUE` format, preferrably one per line
 
 ### Secrets
 
@@ -32,7 +33,6 @@ secret name          | required | description
 -------------------- | -------- | --------------------------------------------------------------------
 `dockerhub_username` | True     | The Docker Hub username to use when uploading the image
 `dockerhub_token`    | True     | The Docker Hub personal access token to use when uploading the image
-
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ edencehealth/workflows/.github/workflows/dockerimage.yml@main
 
 input name       | required | type    | default                                      | description
 ---------------- | -------- | ------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-`build_args`     | False    | string  | ""                                           | Additional build arguments in `KEY=VALUE` format, preferrably one per line
+`build_args`     | False    | string  | `""` (empty string)                          | Additional build arguments in `KEY=VALUE` format, preferrably one per line
 `container_name` | True     | string  | `-`                                          | The base name of the docker container; e.g. just the "xyz" part of "edence/xyz:latest"
 `context_path`   | False    | string  | `.`                                          | The path (relative within the repo) of the directory that contains the Dockerfile
 `dockerhub_org`  | False    | string  | `edence`                                     | The Docker Hub organization name or username where the image should be uploaded; e.g. just the "edence" part of "edence/xyz:latest"; leave blank to skip the normal Docker Hub tag
 `github_org`     | False    | string  | `edencehealth`                               | The GitHub organization name or username where the image should be uploaded; e.g. just the "edencehealth" part of "edencehealth/xyz:latest"; leave blank to skip the normal GitHub tag
 `platforms`      | False    | string  | `linux/amd64,linux/arm64`                    | The comma-separated target platform(s) to use when building the image
 `push`           | False    | boolean | `${{ github.event_name != 'pull_request' }}` | Whether to push the image to the container registries (building without pushing may be useful as a PR check)
-`registry_paths` | False    | string  | ``                                           | Additional registry paths in `KEY=VALUE` format, preferrably one per line
+`registry_paths` | False    | string  | `""` (empty string)                          | Additional registry paths in `KEY=VALUE` format, preferrably one per line
 
 ### Secrets
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ edencehealth/workflows/.github/workflows/dockerimage.yml@main
 
 input name       | required | type    | default                    | description
 ---------------- | -------- | ------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------
+`build_args`     | False    | string  | ``                         | Additional build arguments in `KEY=VALUE` format, preferrably one per line
 `container_name` | True     | string  | &nbsp;                     | The base name of the docker container; e.g. just the `xyz` part of `edence/xyz:latest`
+`context_path`   | False    | string  | `.`                        | The path (relative within the repo) of the directory that contains the Dockerfile
 `dockerhub_org`  | False    | string  | `edence`                   | The Docker Hub organization name or username where the image should be uploaded; e.g. just the `edence` part of `edence/xyz:latest`
 `github_org`     | False    | string  | `edencehealth`             | The GitHub organization name or username where the image should be uploaded; e.g. just the `edencehealth` part of `edencehealth/xyz:latest`
-`context_path`   | False    | string  | `.`                        | The path (relative within the repo) of the directory that contains the Dockerfile
 `platforms`      | False    | string  | `linux/amd64,linux/arm64`  | The comma-separated target platform(s) to use when building the image
 `push`           | False    | boolean | True if not a pull request | Whether to push the image to the container registries (building without pushing may be useful as a PR check)
 
@@ -57,4 +58,31 @@ jobs:
       container_name: demoapp
       context_path: app
     secrets: inherit
+```
+
+Some arguments are multi-line arguments, here's an example of that
+
+```yaml
+name: docker image
+
+on:
+  push:
+    paths:
+      - "etl/**"
+      - ".github/workflows/docker.yml"
+    branches:
+      - main
+    tags:
+      - '*.*.*'
+
+jobs:
+  dockerimage:
+    uses: edencehealth/workflows/.github/workflows/dockerimage.yml@main
+    with:
+      container_name: demo_etl
+      context_path: etl
+    secrets: inherit
+    build-args: |
+      DEV_BUILD=1
+      FAIL_FAST=0
 ```


### PR DESCRIPTION
Adds support for arbitrary additional build arguments and arbitrary registry paths. Specifying empty gh_org and dh_org disables those tags & registries.

Using a ternary form that I'm not a fan of, but our options are limited. We may want to process and re-emit this in a metadata step to keep the code cleaner. Need to think about it.