### PR TITLE
revert aa501f68681af96c6de7ac9cbcb74e28c566c3dd

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -114,8 +114,6 @@ jobs:
   image:
     # https://docs.github.com/en/actions/examples/using-scripts-to-test-your-code-on-a-runner#example-workflow
     runs-on: ${{ fromJSON(inputs.runs_on) }}
-    permissions:
-      packages: write
     outputs:
       tags: |-
         ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I wanted to use something like this:

```yaml
jobs:
  image:
    # https://docs.github.com/en/actions/examples/using-scripts-to-test-your-code-on-a-runner#example-workflow
    runs-on: ${{ fromJSON(inputs.runs_on) }}
    permissions:
      packages: ${{ inputs.github_org != '' && 'write' || 'read' }}
```

...but we can't use inputs here. I don't want to force GHCR use, so I'll roll back.